### PR TITLE
Fix GitHub Pages deployment permissions

### DIFF
--- a/.github/workflows/build-book.yml
+++ b/.github/workflows/build-book.yml
@@ -8,6 +8,11 @@ on:
     branches: [ main ]
   workflow_dispatch:
 
+permissions:
+  contents: write
+  pages: write
+  id-token: write
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This PR fixes the GitHub Pages deployment failure by adding the necessary permissions for the GitHub Actions bot to push to the gh-pages branch.

## Changes
- Add  permission to allow pushing to gh-pages branch
- Add  and  permissions for GitHub Pages deployment

## Context
The previous deployment failed with:


This is a common issue when using GitHub Actions to deploy to GitHub Pages. The fix is to explicitly grant write permissions to the workflow.

🤖 Generated with [Claude Code](https://claude.ai/code)