### PR TITLE
Remove custom domain to use github.io URL

### DIFF
--- a/.github/workflows/build-book.yml
+++ b/.github/workflows/build-book.yml
@@ -121,4 +121,3 @@ jobs:
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         publish_dir: book/_build/html
-        cname: llm-eti.maxghenis.com  # Optional: add your custom domain


### PR DESCRIPTION
Removes the CNAME configuration from the GitHub Pages deployment workflow to use the default github.io URL instead of the custom domain.