### PR TITLE
Allow flexible MTRs in PKNF sims

### DIFF
--- a/book/scripts/run_pknf_simulation.py
+++ b/book/scripts/run_pknf_simulation.py
@@ -112,7 +112,9 @@ def main():
         safe_model_name = model.replace("/", "_")
         low_rate_int = int(args.low_rate)
         high_rate_int = int(args.high_rate)
-        filename = f"pknf_results_{safe_model_name}_{low_rate_int}pct_{high_rate_int}pct"
+        filename = (
+            f"pknf_results_{safe_model_name}_{low_rate_int}pct_{high_rate_int}pct"
+        )
         if args.test:
             filename += "_test"
 

--- a/book/scripts/run_pknf_simulation.py
+++ b/book/scripts/run_pknf_simulation.py
@@ -34,6 +34,18 @@ def main():
     parser.add_argument(
         "--cache-analysis", action="store_true", help="Analyze cache usage after run"
     )
+    parser.add_argument(
+        "--low-rate",
+        type=float,
+        default=25.0,
+        help="Low marginal tax rate as a percentage (default: 25)",
+    )
+    parser.add_argument(
+        "--high-rate",
+        type=float,
+        default=50.0,
+        help="High marginal tax rate as a percentage (default: 50)",
+    )
     args = parser.parse_args()
 
     # Check for API key
@@ -80,10 +92,16 @@ def main():
         print(f"  - Total treatments: {len(treatments)}")
         print(f"  - Total rounds: {rounds}")
         print(f"  - Cache enabled: {client.use_cache}")
+        print(f"  - Low rate: {args.low_rate}%")
+        print(f"  - High rate: {args.high_rate}%")
 
         # Run experiment
         results_df = experiment.run_experiment(
-            treatments=treatments, rounds=rounds, subjects_per_treatment=num_subjects
+            treatments=treatments,
+            rounds=rounds,
+            subjects_per_treatment=num_subjects,
+            low_rate=args.low_rate,
+            high_rate=args.high_rate,
         )
 
         # Save results
@@ -92,7 +110,9 @@ def main():
 
         # if model string has a slash (e.g. "deepseek-ai/DeepSeek-V3"), replace with underscore for filename
         safe_model_name = model.replace("/", "_")
-        filename = f"pknf_results_{safe_model_name}"
+        low_rate_int = int(args.low_rate)
+        high_rate_int = int(args.high_rate)
+        filename = f"pknf_results_{safe_model_name}_{low_rate_int}pct_{high_rate_int}pct"
         if args.test:
             filename += "_test"
 

--- a/llm_eti/edsl_client.py
+++ b/llm_eti/edsl_client.py
@@ -170,6 +170,8 @@ TAXABLE_INCOME: <number>"""
         labor_endowment: int,
         wage_per_unit: float = 20,
         rounds: int = 16,
+        low_rate: float = 25,
+        high_rate: float = 50,
     ) -> "Survey":
         """Create survey for PKNF lab experiment replication.
 
@@ -179,6 +181,8 @@ TAXABLE_INCOME: <number>"""
             labor_endowment: Maximum labor units available
             wage_per_unit: Wage per unit of labor (default: 20)
             rounds: Number of rounds (default: 16)
+            low_rate: Low marginal tax rate as a percentage (default: 25)
+            high_rate: High marginal tax rate as a percentage (default: 50)
 
         Returns:
             EDSL Survey object
@@ -200,12 +204,12 @@ TAXABLE_INCOME: <number>"""
         #         tax_desc = "a progressive tax where income up to 400 is taxed at 25%, and income above 400 is taxed at 50%"
 
         if tax_schedule == "flat25":
-            rate1 = 25
+            rate1 = low_rate
         elif tax_schedule == "flat50":
-            rate1 = 50
+            rate1 = high_rate
         else:  # progressive
-            rate1 = 25
-            rate2 = 50
+            rate1 = low_rate
+            rate2 = high_rate
         bkt1 = 400
 
         # Create base prompt with simpler language

--- a/llm_eti/simulation_engine.py
+++ b/llm_eti/simulation_engine.py
@@ -168,6 +168,8 @@ class LabExperimentSimulation:
         treatments: List[str],
         rounds: Optional[int] = None,
         subjects_per_treatment: int = 100,
+        low_rate: float = 25.0,
+        high_rate: float = 50.0,
     ) -> pd.DataFrame:
         """Run the full lab experiment simulation.
 
@@ -175,6 +177,8 @@ class LabExperimentSimulation:
             treatments: List of treatment labels to run (e.g., ["Prog,Prog", "Prog,Flat25"])
             rounds: Number of rounds (default: 16 from config)
             subjects_per_treatment: Number of subjects per treatment group
+            low_rate: Low marginal tax rate as a percentage (default: 25)
+            high_rate: High marginal tax rate as a percentage (default: 50)
 
         Returns:
             DataFrame with experiment results
@@ -216,6 +220,8 @@ class LabExperimentSimulation:
                         "labor_endowment": int(labor_endowments[round_idx]),
                         "wage_per_unit": self.config["wage_per_unit"],
                         "rounds": rounds,
+                        "low_rate": low_rate,
+                        "high_rate": high_rate,
                     }
 
                     # Run survey
@@ -230,9 +236,14 @@ class LabExperimentSimulation:
                         result = results[0]
                         income_choice = result.get("income", 0)
 
+                        # Relabel treatment to reflect actual rates used
+                        output_label = treatment.label.replace(
+                            "Flat25", f"Flat{int(low_rate)}"
+                        ).replace("Flat50", f"Flat{int(high_rate)}")
+
                         all_results.append(
                             {
-                                "treatment": treatment.label,
+                                "treatment": output_label,
                                 "subject_id": subject_id,
                                 "round": round_num,
                                 "tax_schedule": schedule.value,


### PR DESCRIPTION
This PR updates the PKNF simulation modules/functions to make the low and high marginal tax rates arguments.  